### PR TITLE
Use Result enum for getTemp error codes

### DIFF
--- a/OneWireESP32.cpp
+++ b/OneWireESP32.cpp
@@ -5,12 +5,6 @@ https://github.com/junkfix/esp32-ds18b20
 #include <Arduino.h>
 #include "OneWireESP32.h"
 
-#define OWR_OK	0
-#define OWR_CRC	1
-#define OWR_BAD_DATA	2
-#define OWR_TIMEOUT	3
-#define OWR_DRIVER	4
-
 #define OW_RESET_PULSE	500
 #define OW_RESET_WAIT	200
 #define OW_RESET_PRESENCE_WAIT_MIN	15
@@ -252,36 +246,32 @@ void OneWire32::request(){
 
 const uint8_t crc_table[] = {0, 94, 188, 226, 97, 63, 221, 131, 194, 156, 126, 32, 163, 253, 31, 65, 157, 195, 33, 127, 252, 162, 64, 30, 95, 1, 227, 189, 62, 96, 130, 220, 35, 125, 159, 193, 66, 28, 254, 160, 225, 191, 93, 3, 128, 222, 60, 98, 190, 224, 2, 92, 223, 129, 99, 61, 124, 34, 192, 158, 29, 67, 161, 255, 70, 24, 250, 164, 39, 121, 155, 197, 132, 218, 56, 102, 229, 187, 89, 7, 219, 133, 103, 57, 186, 228, 6, 88, 25, 71, 165, 251, 120, 38, 196, 154, 101, 59, 217, 135, 4, 90, 184, 230, 167, 249, 27, 69, 198, 152, 122, 36, 248, 166, 68, 26, 153, 199, 37, 123, 58, 100, 134, 216, 91, 5, 231, 185, 140, 210, 48, 110, 237, 179, 81, 15, 78, 16, 242, 172, 47, 113, 147, 205, 17, 79, 173, 243, 112, 46, 204, 146, 211, 141, 111, 49, 178, 236, 14, 80, 175, 241, 19, 77, 206, 144, 114, 44, 109, 51, 209, 143, 12, 82, 176, 238, 50, 108, 142, 208, 83, 13, 239, 177, 240, 174, 76, 18, 145, 207, 45, 115, 202, 148, 118, 40, 171, 245, 23, 73, 8, 86, 180, 234, 105, 55, 213, 139, 87, 9, 235, 181, 54, 104, 138, 212, 149, 203, 41, 119, 244, 170, 72, 22, 233, 183, 85, 11, 136, 214, 52, 106, 43, 117, 151, 201, 74, 20, 246, 168, 116, 42, 200, 150, 21, 75, 169, 247, 182, 232, 10, 84, 215, 137, 107, 53};
 
-uint8_t OneWire32::getTemp(uint64_t &addr, float &temp){
-	uint8_t error = OWR_OK;
-	if(!drv){return OWR_DRIVER;}
-	if(reset()){	//connected
-		write(0x55);
-		uint8_t *a = (uint8_t *)&addr;
-		for(uint8_t i = 0; i < 8; i++){
-			write(a[i]);
-		}
-		write(0xBE);	// Read
-		uint8_t data[9]; uint16_t zero = 0; uint8_t crc = 0;
-		for(uint8_t j = 0; j < 9; j++){
-			if(!read(data[j],8)){data[j] = 0;}
-			zero += data[j];
-			if(j < 8 ){crc = crc_table[crc ^ data[j]];}
-		}
-		if(zero != 0x8f7 && zero){
-			if(data[8] == crc ){	//CRC OK
-				int16_t t = (data[1] << 8) | data[0];
-				temp = ((float)t / 16.0);
-			}else{
-				error = OWR_CRC;
-			}
-		}else{
-			error = OWR_BAD_DATA;
-		}
-	}else{
-		error = OWR_TIMEOUT;
+OneWire32::Result OneWire32::getTemp(uint64_t &addr, float &temp){
+	if(!drv){return Result::DRIVER;}
+	if(!reset()){
+		return Result::TIMEOUT;
 	}
-	return error;
+	write(0x55);
+	uint8_t *a = (uint8_t *)&addr;
+	for(uint8_t i = 0; i < 8; i++){
+		write(a[i]);
+	}
+	write(0xBE);	// Read
+	uint8_t data[9]; uint16_t zero = 0; uint8_t crc = 0;
+	for(uint8_t j = 0; j < 9; j++){
+		if(!read(data[j],8)){data[j] = 0;}
+		zero += data[j];
+		if(j < 8 ){crc = crc_table[crc ^ data[j]];}
+	}
+	if(zero == 0 || zero == 0x8f7){
+		return Result::BAD_DATA;
+	}
+	if(data[8] != crc){
+		return Result::CRC;
+	}
+	int16_t t = (data[1] << 8) | data[0];
+	temp = ((float)t / 16.0);
+	return Result::OK;
 }
 
 

--- a/OneWireESP32.h
+++ b/OneWireESP32.h
@@ -30,12 +30,21 @@ class OneWire32 {
 		rmt_symbol_word_t owbuf[MAX_BLOCKS];
 		QueueHandle_t owqueue;
 		uint8_t drv = 0;
+
 	public:
+		enum Result {
+			OK = 0,
+			CRC = 1,
+			BAD_DATA = 2,
+			TIMEOUT = 3,
+			DRIVER	= 4
+		};
+
 		OneWire32(uint8_t pin);
 		~OneWire32();
 		bool reset();
 		void request();
-		uint8_t getTemp(uint64_t &addr, float &temp);
+		Result getTemp(uint64_t &addr, float &temp);
 		uint8_t search(uint64_t *addresses, uint8_t total);
 		bool read(uint8_t &data, uint8_t len = 8);
 		bool write(const uint8_t data, uint8_t len = 8);

--- a/examples/ds18b20/ds18b20.ino
+++ b/examples/ds18b20/ds18b20.ino
@@ -27,7 +27,7 @@ void tempTask(void *pvParameters){
 		ds.request();
 		vTaskDelay(750 / portTICK_PERIOD_MS);
 		for(byte i = 0; i < MaxDevs; i++){
-			uint8_t err = ds.getTemp(addr[i], currTemp[i]);
+			OneWire32::Result err = ds.getTemp(addr[i], currTemp[i]);
 			if(err){
 				const char *errt[] = {"", "CRC", "BAD","DC","DRV"};
 				Serial.print(i); Serial.print(": "); Serial.println(errt[err]);

--- a/examples/loop/loop.ino
+++ b/examples/loop/loop.ino
@@ -2,8 +2,8 @@
 
 #include "OneWireESP32.h"
 const uint8_t MaxDevs = 2;
-uint8_t tempErr[MaxDevs];
-uint8_t tempReady[MaxDevs];
+OneWire32::Result tempErr[MaxDevs];
+bool tempReady[MaxDevs];
 float currTemp[MaxDevs];
 uint64_t addr[MaxDevs];
 
@@ -28,7 +28,7 @@ void tempTask(void *pvParameters){
 		vTaskDelay(750 / portTICK_PERIOD_MS);
 		for(byte i = 0; i < MaxDevs; i++){
 			tempErr[i] = ds.getTemp(addr[i], currTemp[i]);
-			tempReady[i] = 1;
+			tempReady[i] = true;
 		}
 		vTaskDelay(3000 / portTICK_PERIOD_MS); //sleep for 3 sec
 	}
@@ -45,7 +45,7 @@ void loop() {
 
 	for(byte i = 0; i < MaxDevs; i++){
 		if(tempReady[i]){
-			tempReady[i] = 0;
+			tempReady[i] = false;
 			if(tempErr[i]){
 				const char *errt[] = {"", "CRC", "BAD","DC","DRV"};
 				Serial.print(i); Serial.print(": "); Serial.println(errt[tempErr[i]]);


### PR DESCRIPTION
Rather than the caller having to implicitly know what each code represents.